### PR TITLE
Proposed Keyboard Profiles for iOS Keyboard Responsiveness

### DIFF
--- a/Limelight/Database/TemporarySettings.m
+++ b/Limelight/Database/TemporarySettings.m
@@ -15,6 +15,7 @@
     self = [self init];
     
     self.parent = settings;
+    // add movement profile to settings
     
 #if TARGET_OS_TV
     NSInteger _bitrate = [[NSUserDefaults standardUserDefaults] integerForKey:@"bitrate"];

--- a/Limelight/Input/KeyboardMovementProfile.h
+++ b/Limelight/Input/KeyboardMovementProfile.h
@@ -1,0 +1,41 @@
+//
+//  KeyboardMovementProfile.h
+//  Moonlight
+//
+//  Created by Hugo on 2/20/19.
+//  Copyright © 2019 Moonlight Game Streaming Project. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+typedef NS_ENUM(NSInteger, MovementProfile) {
+    MovementProfileWasd,
+    MovementProfileDefault
+};
+
+@interface KeyboardMovementProfile : NSObject
+@property (readonly, nonatomic, assign) MovementProfile activeProfile;
+- (instancetype)initWithProfile:(MovementProfile)movementProfile;
+- (int)delayForKeyCode:(u_short)keyCode;
+/**
+ *  @description
+ *      Current key state for the pressed keycode.
+ *      True indicates the key is down, false indicates its up.
+ *      Each keycode state begins in the down state.
+ */
+- (BOOL)keyPressState:(u_short)keyCode;
+/**
+ *  @description
+ *      Whether or not the keycode state is toggable.
+ */
+- (BOOL)isToggable:(u_short)keyCode;
+/**
+ *  @description
+ *      Toggles the down state of the keycode.
+ */
+- (void)toggleDownState:(u_short)keyCode;
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Limelight/Input/KeyboardMovementProfile.m
+++ b/Limelight/Input/KeyboardMovementProfile.m
@@ -1,0 +1,74 @@
+//
+//  KeyboardMovementProfile.m
+//  Moonlight
+//
+//  Created by Hugo on 2/20/19.
+//  Copyright © 2019 Moonlight Game Streaming Project. All rights reserved.
+//
+
+#import "KeyboardMovementProfile.h"
+typedef NS_ENUM(u_short, KeyCode) {
+    KeyCode_w = 87,
+    KeyCode_a = 65,
+    KeyCode_s = 83,
+    KeyCode_d = 68,
+    KeyCode_q = 81,
+    KeyCode_e = 69,
+};
+
+@interface KeyboardMovementProfile()
+@property (nonatomic) NSMutableDictionary *downStates;
+@end
+
+@implementation KeyboardMovementProfile
+- (instancetype)initWithProfile:(MovementProfile)movementProfile {
+    if ((self = [super init])) {
+        _activeProfile = movementProfile;
+        _downStates = [NSMutableDictionary new];
+    }
+    return self;
+}
+
+- (NSString *)keycodeMapString:(u_short)keyCode {
+    return [NSNumber numberWithShort:keyCode].description;
+}
+
+- (BOOL)downState:(u_short)keyCode {
+    NSString *key = [self keycodeMapString:keyCode];
+    if (!_downStates[key])
+        _downStates[key] = [NSNumber numberWithBool:YES];
+    return [_downStates[key] boolValue];
+}
+
+- (void)toggleDownState:(u_short)keyCode {
+    NSString *key = [self keycodeMapString:keyCode];
+    BOOL currState = [_downStates[key] boolValue];
+    _downStates[key] = [NSNumber numberWithBool:!currState];
+}
+
+- (BOOL)keyPressState:(u_short)keyCode {
+    switch (keyCode) {
+        case KeyCode_w: return [self downState:keyCode];
+        default: return NO;
+    }
+}
+
+- (BOOL)isToggable:(u_short)keyCode {
+    switch (keyCode) {
+        case KeyCode_w: return YES;
+        default: return NO;
+    }
+}
+
+- (int)delayForKeyCode:(u_short)keyCode {
+    switch (keyCode) {
+        case KeyCode_q:
+        case KeyCode_e:
+        case KeyCode_s:
+        case KeyCode_a:
+        case KeyCode_d: return 300;
+        case KeyCode_w: return 1000;
+        default: return 50;
+    }
+}
+@end

--- a/Limelight/ViewControllers/SettingsViewController.m
+++ b/Limelight/ViewControllers/SettingsViewController.m
@@ -42,6 +42,8 @@ static const int bitrateTable[] = {
     100000
 };
 
+// add keyboard profile to settings
+
 -(int)getSliderValueForBitrate:(NSInteger)bitrate {
     int i;
     

--- a/Moonlight.xcodeproj/project.pbxproj
+++ b/Moonlight.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		3DC876C5221E85B30092845E /* KeyboardMovementProfile.m in Sources */ = {isa = PBXBuildFile; fileRef = 3DC876C4221E85B30092845E /* KeyboardMovementProfile.m */; };
 		693B3A9B218638CD00982F7B /* Settings.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 693B3A9A218638CD00982F7B /* Settings.bundle */; };
 		9832D1361BBCD5C50036EF48 /* TemporaryApp.m in Sources */ = {isa = PBXBuildFile; fileRef = 9832D1351BBCD5C50036EF48 /* TemporaryApp.m */; };
 		9865DC30213260B40005B9B9 /* libmoonlight-common-tv.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FB1A68152132509400507771 /* libmoonlight-common-tv.a */; };
@@ -161,6 +162,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		3DC876C3221E85B30092845E /* KeyboardMovementProfile.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = KeyboardMovementProfile.h; sourceTree = "<group>"; };
+		3DC876C4221E85B30092845E /* KeyboardMovementProfile.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = KeyboardMovementProfile.m; sourceTree = "<group>"; };
 		693B3A9A218638CD00982F7B /* Settings.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; path = Settings.bundle; sourceTree = "<group>"; };
 		98132E8C20BC9A62007A053F /* Moonlight v1.1.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Moonlight v1.1.xcdatamodel"; sourceTree = "<group>"; };
 		9832D1341BBCD5C50036EF48 /* TemporaryApp.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TemporaryApp.h; path = Database/TemporaryApp.h; sourceTree = "<group>"; };
@@ -558,6 +561,8 @@
 				FB1A674C2131E65900507771 /* KeyboardSupport.m */,
 				9897B6A0221260EF00966419 /* Controller.m */,
 				9897B6A32212610800966419 /* Controller.h */,
+				3DC876C3221E85B30092845E /* KeyboardMovementProfile.h */,
+				3DC876C4221E85B30092845E /* KeyboardMovementProfile.m */,
 			);
 			path = Input;
 			sourceTree = "<group>";
@@ -1061,6 +1066,7 @@
 				FB290D0719B2C406004C83CF /* Limelight.xcdatamodeld in Sources */,
 				FB1A674D2131E65900507771 /* KeyboardSupport.m in Sources */,
 				FB89463219F646E200339C8A /* VideoDecoderRenderer.m in Sources */,
+				3DC876C5221E85B30092845E /* KeyboardMovementProfile.m in Sources */,
 				FB290D0419B2C406004C83CF /* AppDelegate.m in Sources */,
 				FB9AFD401A7E127D00872C98 /* AppListResponse.m in Sources */,
 				FB89463419F646E200339C8A /* Utils.m in Sources */,


### PR DESCRIPTION
(DONT MERGE)

Hey guys,

I love this project and have been using it for some time now. I especially like to use it on my iPad but I really can't use it well while only using my BLE Logitech keyboard on my iPad when I try moving my characters in various games (see #337).

I made some modifications in a separate fork to alleviate this issue, by providing a *PROPOSED* foundation for keyboard profiles.

At the very least, I'm comfortably able to play WoW and other similar games now only using a keyboard. 

This branch has the following changes currently:

```
- WIP iOS hardware keyboard responsiveness updates 
for games where long down states are used for interactions 
with a proposed api for keyboard profiles*

- adjust left click drag time
- added support for right click drag behavior

*The problem this solves is responsiveness from held down keypresses.
We don't get down states from hardware keyboards (now atleast).
This attempts to circumvent the issue by making those sensitive
keys toggable in the interim, as well as controlling the delay between
specific key presses.

This issue will go away if apple exposes that in a future api update, 
at which point we can decide to either keep these profiles, or deprecate them.
This was designed to be more customizable than just toggable, 
but for now thats all I've chosen to implement.
```

If you guys think this can be useful and is an 'ok' work around for the 
current circumstances, I can expand the branch by adding settings
 UI for the keyboard profiles. 

Also, any advice on the current code structure and functionality is warmly
welcomed.

Let me know your thoughts, thanks!