### PR TITLE
Capped bitrate at 100Mbps.

### DIFF
--- a/Limelight/ViewControllers/SettingsViewController.m
+++ b/Limelight/ViewControllers/SettingsViewController.m
@@ -199,7 +199,7 @@ static const int bitrateTable[] = {
     }
     
     // We should always be exactly on a slider position with default bitrates
-    _bitrate = defaultBitrate;
+    _bitrate = MIN(defaultBitrate, 100000);
     assert(bitrateTable[[self getSliderValueForBitrate:_bitrate]] == _bitrate);
     [self.bitrateSlider setValue:[self getSliderValueForBitrate:_bitrate] animated:YES];
     


### PR DESCRIPTION
Choosing 4K 120Hz was causing an assert/crash.

Either cap the bitrate to 100, or read the last entry of the bitrateTable and remove the assert?