### PR TITLE
Fixed crash on iPad due to missing up UIAlertController popoverPresentation.

### DIFF
--- a/Limelight/UIAppView.h
+++ b/Limelight/UIAppView.h
@@ -11,8 +11,8 @@
 
 @protocol AppCallback <NSObject>
 
-- (void) appClicked:(TemporaryApp*) app;
-- (void) appLongClicked:(TemporaryApp*) app;
+- (void) appClicked:(TemporaryApp*)app view:(UIView*)view;
+- (void) appLongClicked:(TemporaryApp*)app view:(UIView*)view;
 
 @end
 

--- a/Limelight/UIAppView.m
+++ b/Limelight/UIAppView.m
@@ -50,10 +50,10 @@ static UIImage* noImage;
     [self addGestureRecognizer:longPressRecognizer];
     
     if (@available(iOS 9.0, tvOS 9.0, *)) {
-        [self addTarget:self action:@selector(appClicked) forControlEvents:UIControlEventPrimaryActionTriggered];
+        [self addTarget:self action:@selector(appClicked:) forControlEvents:UIControlEventPrimaryActionTriggered];
     }
     else {
-        [self addTarget:self action:@selector(appClicked) forControlEvents:UIControlEventTouchUpInside];
+        [self addTarget:self action:@selector(appClicked:) forControlEvents:UIControlEventTouchUpInside];
     }
     
     [self addTarget:self action:@selector(buttonSelected:) forControlEvents:UIControlEventTouchDown];
@@ -79,13 +79,13 @@ static UIImage* noImage;
     return self;
 }
 
-- (void) appClicked {
-    [_callback appClicked:_app];
+- (void) appClicked:(UIView *)view {
+    [_callback appClicked:_app view:view];
 }
 
 - (void) appLongClicked:(UILongPressGestureRecognizer*)gesture {
     if (gesture.state == UIGestureRecognizerStateBegan) {
-        [_callback appLongClicked:_app];
+        [_callback appLongClicked:_app view:self];
     }
 }
 

--- a/Limelight/ViewControllers/MainFrameViewController.m
+++ b/Limelight/ViewControllers/MainFrameViewController.m
@@ -669,7 +669,7 @@ static NSMutableSet* hostList;
     }
 }
 
-- (void) appLongClicked:(TemporaryApp*) app {
+- (void)appLongClicked:(TemporaryApp *)app view:(UIView *)view {
     Log(LOG_D, @"Long clicked app: %@", app.name);
     
     [_appManager stopRetrieving];
@@ -795,10 +795,15 @@ static NSMutableSet* hostList;
     }
     
     [alertController addAction:[UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleCancel handler:nil]];
+
+    // these two lines are required for iPad support of UIAlertSheet
+    alertController.popoverPresentationController.sourceView = view;
+    
+    alertController.popoverPresentationController.sourceRect = CGRectMake(view.bounds.size.width / 2.0, view.bounds.size.height / 2.0, 1.0, 1.0); // center of the view
     [[self activeViewController] presentViewController:alertController animated:YES completion:nil];
 }
 
-- (void) appClicked:(TemporaryApp *)app {
+- (void) appClicked:(TemporaryApp *)app view:(UIView *)view {
     Log(LOG_D, @"Clicked app: %@", app.name);
     
     [_appManager stopRetrieving];
@@ -814,7 +819,7 @@ static NSMutableSet* hostList;
     
     if ([self findRunningApp:app.host]) {
         // If there's a running app, display a menu
-        [self appLongClicked:app];
+        [self appLongClicked:app view:view];
     } else {
         [self prepareToStreamApp:app];
         [self performSegueWithIdentifier:@"createStreamFrame" sender:nil];
@@ -843,7 +848,7 @@ static NSMutableSet* hostList;
 
 #if TARGET_OS_TV
 - (void)collectionView:(UICollectionView *)collectionView didSelectItemAtIndexPath:(NSIndexPath *)indexPath {
-    [self appClicked:_sortedAppList[indexPath.row]];
+    [self appClicked:_sortedAppList[indexPath.row] view:nil];
 }
 #endif
 


### PR DESCRIPTION
Tapping and/or long pressing app cells on iPad would crash. This is because the UIAlertController you were using was missing popoverPresentation sourceView and sourceRect. Since you already avoid this crash for the host cells I just adapted that to app cells.