### PR TITLE
Use actual number of audio channels

### DIFF
--- a/Limelight/ViewControllers/MainFrameViewController.m
+++ b/Limelight/ViewControllers/MainFrameViewController.m
@@ -631,8 +631,19 @@ static NSMutableSet* hostList;
     _streamConfig.multiController = streamSettings.multiController;
     _streamConfig.gamepadMask = [ControllerSupport getConnectedGamepadMask:_streamConfig];
     
+    // Probe for supported channel configurations.
+    // First try to switch audio route to max output channels is possible
+    AVAudioSession *audio_instance = [AVAudioSession sharedInstance];
+    long maxOutputChannels = audio_instance.maximumOutputNumberOfChannels;
+    Log(LOG_I, @"Audio device supports %d channels", maxOutputChannels);
+    
+    bool sucsess = [audio_instance setPreferredOutputNumberOfChannels:maxOutputChannels error:nil];
+    if (sucsess && [audio_instance outputNumberOfChannels] == maxOutputChannels){
+        Log(LOG_I, @"Switched audio device to %d channels", maxOutputChannels);
+    } else {
+        Log(LOG_I, @"Failed to switch audio device to %d channels", maxOutputChannels);
+    }
 
-    // Probe for supported channel configurations
     long outputChannels = [AVAudioSession sharedInstance].outputNumberOfChannels;
     Log(LOG_I, @"Audio device supports %d channels", outputChannels);
     if (outputChannels >= 8) {

--- a/Limelight/ViewControllers/MainFrameViewController.m
+++ b/Limelight/ViewControllers/MainFrameViewController.m
@@ -633,7 +633,7 @@ static NSMutableSet* hostList;
     
 
     // Probe for supported channel configurations
-    long outputChannels = [AVAudioSession sharedInstance].maximumOutputNumberOfChannels;
+    long outputChannels = [AVAudioSession sharedInstance].outputNumberOfChannels;
     Log(LOG_I, @"Audio device supports %d channels", outputChannels);
     if (outputChannels >= 8) {
         _streamConfig.audioConfiguration = AUDIO_CONFIGURATION_71_SURROUND;


### PR DESCRIPTION
Fixes #484 On Apple TV maximumOutputNumberOfChannels reports 5.1 audio even when actually there is only stereo audio enabled. This leads to having input from PC being processed as 5.1 even when device is not capable of doing so and ultimately to having no audio. 

