### PR TITLE
feat: If the frame will be immediately override, do not show it

### DIFF
--- a/Limelight/Stream/Connection.m
+++ b/Limelight/Stream/Connection.m
@@ -95,7 +95,7 @@ void DrStop(void)
     }
 }
 
-int DrSubmitDecodeUnit(PDECODE_UNIT decodeUnit)
+int DrSubmitDecodeUnit(PDECODE_UNIT decodeUnit, BOOL display)
 {
     int offset = 0;
     int ret;
@@ -140,7 +140,8 @@ int DrSubmitDecodeUnit(PDECODE_UNIT decodeUnit)
                                         length:entry->length
                                     bufferType:entry->bufferType
                                      frameType:decodeUnit->frameType
-                                           pts:decodeUnit->presentationTimeMs];
+                                           pts:decodeUnit->presentationTimeMs
+                                       display: display];
             if (ret != DR_OK) {
                 free(data);
                 return ret;
@@ -159,7 +160,8 @@ int DrSubmitDecodeUnit(PDECODE_UNIT decodeUnit)
                                  length:offset
                              bufferType:BUFFER_TYPE_PICDATA
                               frameType:decodeUnit->frameType
-                                    pts:decodeUnit->presentationTimeMs];
+                                    pts:decodeUnit->presentationTimeMs
+                                display: display];
 }
 
 int ArInit(int audioConfiguration, POPUS_MULTISTREAM_CONFIGURATION opusConfig, void* context, int flags)

--- a/Limelight/Stream/VideoDecoderRenderer.h
+++ b/Limelight/Stream/VideoDecoderRenderer.h
@@ -20,6 +20,6 @@
 
 - (void)updateBufferForRange:(CMBlockBufferRef)existingBuffer data:(unsigned char *)data offset:(int)offset length:(int)nalLength;
 
-- (int)submitDecodeBuffer:(unsigned char *)data length:(int)length bufferType:(int)bufferType frameType:(int)frameType pts:(unsigned int)pts;
+- (int)submitDecodeBuffer:(unsigned char *)data length:(int)length bufferType:(int)bufferType frameType:(int)frameType pts:(unsigned int)pts display:(BOOL)display;
 
 @end


### PR DESCRIPTION
Part of what was done in #501. In the same DisplayLink tick its no use to display more than 1  frame, so we ignore all but the last