### PR TITLE
[WIP] Use vt for manually decoding frames. Fixes #533

### DIFF
--- a/Limelight/Stream/Connection.m
+++ b/Limelight/Stream/Connection.m
@@ -55,14 +55,9 @@ int DrDecoderSetup(int videoFormat, int width, int height, int redrawRate, void*
     return 0;
 }
 
-void DrStart(void)
+void DrCleanup(void)
 {
-    [renderer start];
-}
-
-void DrStop(void)
-{
-    [renderer stop];
+    [renderer cleanup];
 }
 
 -(BOOL) getVideoStats:(video_stats_t*)stats
@@ -433,9 +428,9 @@ void ClSetHdrMode(bool enabled)
 
     LiInitializeVideoCallbacks(&_drCallbacks);
     _drCallbacks.setup = DrDecoderSetup;
-    _drCallbacks.start = DrStart;
-    _drCallbacks.stop = DrStop;
-    _drCallbacks.capabilities = CAPABILITY_PULL_RENDERER | CAPABILITY_REFERENCE_FRAME_INVALIDATION_HEVC;
+    _drCallbacks.cleanup = DrCleanup;
+    _drCallbacks.submitDecodeUnit = DrSubmitDecodeUnit;
+    _drCallbacks.capabilities = CAPABILITY_DIRECT_SUBMIT | CAPABILITY_REFERENCE_FRAME_INVALIDATION_HEVC;
 
     LiInitializeAudioCallbacks(&_arCallbacks);
     _arCallbacks.init = ArInit;

--- a/Limelight/Stream/VideoDecoderRenderer.h
+++ b/Limelight/Stream/VideoDecoderRenderer.h
@@ -15,9 +15,10 @@
 - (id)initWithView:(UIView*)view callbacks:(id<ConnectionCallbacks>)callbacks streamAspectRatio:(float)aspectRatio useFramePacing:(BOOL)useFramePacing;
 
 - (void)setupWithVideoFormat:(int)videoFormat frameRate:(int)frameRate;
-- (void)start;
-- (void)stop;
+- (void)cleanup;
 
 - (int)submitDecodeBuffer:(unsigned char *)data length:(int)length bufferType:(int)bufferType frameType:(int)frameType pts:(unsigned int)pts;
+
+- (OSStatus)decodeFrameWithSampleBuffer:(CMSampleBufferRef)sampleBuffer frameType:(int)frameType;
 
 @end

--- a/Limelight/Stream/VideoDecoderRenderer.m
+++ b/Limelight/Stream/VideoDecoderRenderer.m
@@ -79,6 +79,11 @@
         formatDesc = nil;
     }
     
+    if (formatDescImageBuffer != nil) {
+        CFRelease(formatDescImageBuffer);
+        formatDescImageBuffer = nil;
+    }
+    
     if (decompressionSession != nil){
         VTDecompressionSessionInvalidate(decompressionSession);
         CFRelease(decompressionSession);
@@ -350,21 +355,6 @@ int DrSubmitDecodeUnit(PDECODE_UNIT decodeUnit);
         CFRelease(dataBlockBuffer);
         CFRelease(frameBlockBuffer);
         return DR_NEED_IDR;
-    }
-    
-    CFArrayRef attachments = CMSampleBufferGetSampleAttachmentsArray(sampleBuffer, YES);
-    CFMutableDictionaryRef dict = (CFMutableDictionaryRef)CFArrayGetValueAtIndex(attachments, 0);
-    
-    CFDictionarySetValue(dict, kCMSampleAttachmentKey_IsDependedOnByOthers, kCFBooleanTrue);
-    
-    if (frameType == FRAME_TYPE_PFRAME) {
-        // P-frame
-        CFDictionarySetValue(dict, kCMSampleAttachmentKey_NotSync, kCFBooleanTrue);
-        CFDictionarySetValue(dict, kCMSampleAttachmentKey_DependsOnOthers, kCFBooleanTrue);
-    } else {
-        // I-frame
-        CFDictionarySetValue(dict, kCMSampleAttachmentKey_NotSync, kCFBooleanFalse);
-        CFDictionarySetValue(dict, kCMSampleAttachmentKey_DependsOnOthers, kCFBooleanFalse);
     }
        
     OSStatus decodeStatus = [self decodeFrameWithSampleBuffer: sampleBuffer frameType: frameType];


### PR DESCRIPTION
Two main changes

1 - Use VideoToolbox to manually decode each frame instead of submitting it directly to AVSampleBufferDisplayLayer; I'm not proud of this change, but it was needed to fix https://github.com/moonlight-stream/moonlight-ios/issues/533. There may be some way to fix the issue without needing this change, but I still didn't manage to do it.

2 - Latency and smoothness changes
2.1 - Use Direct Submit in VideoDecodeRenderer (reduces latency)
2.2 - Use PTS information correctly per frame instead of using the DisplayImmediately flag in each sampleBuffer. Together with the change above, I was able to replicate smooth low latency stream as I get into the Nvidia Shield. I think using the flag messed with frame time and caused jittering.

Right now, I'm breaking the "Smooth Stream" option that we added some months ago, but wanted to create the PR either way for us to discuss options @cgutman