### PR TITLE
Adding more Bitrate options to tvOS

### DIFF
--- a/Moonlight TV/Settings.bundle/Root.plist
+++ b/Moonlight TV/Settings.bundle/Root.plist
@@ -75,6 +75,8 @@
 				<string>20 Mbps</string>
 				<string>25 Mbps</string>
 				<string>50 Mbps</string>
+				<string>70 Mbps</string>
+				<string>80 Mbps</string>
 				<string>100 Mbps</string>
 				<string>150 Mbps</string>
 			</array>
@@ -88,6 +90,8 @@
 				<string>20000</string>
 				<string>25000</string>
 				<string>50000</string>
+				<string>70000</string>
+				<string>80000</string>
 				<string>100000</string>
 				<string>150000</string>
 			</array>


### PR DESCRIPTION
Added bitrate value options of 70 and 80 Mbps in the Root.plist file specific to Moonlight TV.