### PR TITLE
Issue #547 fix fullscreen on iPad external monitor, remove UIRequires…

### DIFF
--- a/Limelight/Limelight-Info.plist
+++ b/Limelight/Limelight-Info.plist
@@ -73,7 +73,7 @@
 		<string>armv7</string>
 	</array>
 	<key>UIRequiresFullScreen</key>
-	<true/>
+	<false/>
 	<key>UIStatusBarHidden</key>
 	<true/>
 	<key>UISupportedInterfaceOrientations</key>


### PR DESCRIPTION
I removed the UIRequiresFullScreen to be able to go fullscreen and resize the app on an external display, I tested it on my iPad and my phone (not long on the phone though to be honest) and it seemed to work fine. 

I am a backend / devops person so let me know if this will break current functionality or anything.

![03CA8D5D-1DE2-4F6C-A59F-E6E6BFE2CEBE](https://user-images.githubusercontent.com/1686221/221022543-2de3f9a5-40a9-4734-8ae8-44cfcb0eb082.jpg)
