### PR TITLE
iPadOS External Display Fullscreen Support

### DIFF
--- a/Limelight/Limelight-Info.plist
+++ b/Limelight/Limelight-Info.plist
@@ -69,7 +69,7 @@
 		<string>armv7</string>
 	</array>
 	<key>UIRequiresFullScreen</key>
-	<true/>
+	<false/>
 	<key>UIStatusBarHidden</key>
 	<true/>
 	<key>UISupportedInterfaceOrientations</key>


### PR DESCRIPTION
Simple fork of most recent release with the change made to support fullscreen external displays.

This was brought up in a previous pull request but the user closed it out.
Hope to have something like this rolled out in the next IOS release.

Cheers.