### PR TITLE
Fix broken scrolling behavior on iPad.

### DIFF
--- a/Limelight/Input/StreamView.m
+++ b/Limelight/Input/StreamView.m
@@ -699,26 +699,25 @@ static const double X1_MOUSE_SPEED_DIVISOR = 2.5;
         case UIGestureRecognizerStateEnded:
         default:
             // Ignore recognition failure and other states
-            lastScrollTranslation = CGPointMake(0, 0);
+            lastScrollTranslation = CGPointZero;
             return;
     }
     
     CGPoint currentScrollTranslation = [gesture translationInView:self];
-    
     {
-        short translationDeltaY = ((currentScrollTranslation.y - lastScrollTranslation.y) / self.bounds.size.height) * 120; // WHEEL_DELTA
+        short translationDeltaY = (short)(currentScrollTranslation.y - lastScrollTranslation.y); // WHEEL_DELTA
         if (translationDeltaY != 0) {
             LiSendHighResScrollEvent(translationDeltaY * 20);
-            lastScrollTranslation = currentScrollTranslation;
+            lastScrollTranslation.y += translationDeltaY;
         }
     }
 
     {
-        short translationDeltaX = ((currentScrollTranslation.x - lastScrollTranslation.x) / self.bounds.size.width) * 120; // WHEEL_DELTA
+        short translationDeltaX = (short)(currentScrollTranslation.x - lastScrollTranslation.x); // WHEEL_DELTA
         if (translationDeltaX != 0) {
             // Direction is reversed from vertical scrolling
             LiSendHighResHScrollEvent(-translationDeltaX * 20);
-            lastScrollTranslation = currentScrollTranslation;
+            lastScrollTranslation.x += translationDeltaX;
         }
     }
 }


### PR DESCRIPTION
With the previous behavior, the trackpad was completely broken: all but the sharpest scroll gestures would result in the translation delta being truncated to 0.


I believe the value from `translationInView`, which is already a value in units of pixels, should not be scaled at all.  I also modified the way that `currentScrollTranslation` is updated to avoid losing small movements to truncation rounding errors.


This resulted in much better behavior.


I did most of my testing with the trackpad on the Apple Magic Keyboard for my iPad, as well as a USB mouse with a scroll wheel.