### PR TITLE
Map the "Globe" / "Language" key to Escape

### DIFF
--- a/Limelight/Input/KeyboardSupport.m
+++ b/Limelight/Input/KeyboardSupport.m
@@ -248,6 +248,9 @@
             case UIKeyboardHIDUsageKeyboardRightAlt:
                 keyCode = 0xA5;
                 break;
+            case 669: // This value corresponds to the "Globe" or "Language" key on most Apple branded iPad keyboards.
+                keyCode = 0x1B; // This value corresponds to "Escape", which is missing from most Apple branded iPad keyboards.
+                break;
             default:
                 NSLog(@"Unhandled HID usage: %lu", (unsigned long)key.keyCode);
                 assert(0);

--- a/Limelight/Input/KeyboardSupport.m
+++ b/Limelight/Input/KeyboardSupport.m
@@ -201,7 +201,7 @@
                 keyCode = 0x6B;
                 break;
             case UIKeyboardHIDUsageKeypadEnter:
-                keyCode = 0x0D; // FIXME: Is this correct?
+                keyCode = 0x0D;
                 break;
             case UIKeyboardHIDUsageKeypadPeriod:
                 keyCode = 0x6E;


### PR DESCRIPTION
The "Globe" / "Language" key, which is the bottom-left most key on Apple branded iPad keyboards, is currently unused (it falls through the switch statement).

This commit maps that key to "Escape", which is an important key for many games and other applications, but is not present on most Apple branded iPad keyboards.