### PR TITLE
Disable lowering volume of other apps playing audio

### DIFF
--- a/Limelight/Stream/Connection.m
+++ b/Limelight/Stream/Connection.m
@@ -234,6 +234,9 @@ int ArInit(int audioConfiguration, POPUS_MULTISTREAM_CONFIGURATION opusConfig, v
     // Start playback
     SDL_PauseAudioDevice(audioDevice, 0);
     
+    // Disable lowering volume of other audio streams (SDL sets AVAudioSessionCategoryOptionDuckOthers by default)
+    [[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryPlayback withOptions:AVAudioSessionCategoryOptionMixWithOthers error:nil];
+    
     return 0;
 }
 


### PR DESCRIPTION
SDL by default sets AVAudioSessionCategoryOptionDuckOthers on its audio session, causing iOS to lower the volume of other apps that are playing audio (such as music) while Moonlight is streaming.

Although SDL supports setting a hint to configure which AVAudioSession category and option it sets, there doesn't seem to be any combination that results in a playback-category session without ducking enabled: https://github.com/libsdl-org/SDL/blob/main/src/audio/coreaudio/SDL_coreaudio.m#L423. (I've also tested ambient and that results in no Moonlight audio at all.)

Instead, I set the category and options directly on the audio session right after it's configured by SDL. The audio will still be ducked for a second or so, but afterwards the change takes effect and both Moonlight and background apps play at full volume.