### PR TITLE
[opt] Use UILabel for stats overlay

### DIFF
--- a/Limelight/Utility/PaddedLabel.h
+++ b/Limelight/Utility/PaddedLabel.h
@@ -1,0 +1,15 @@
+//
+//  PaddedLabel.h
+//  Moonlight
+//
+//  Created by Travis Thieman on 5/6/25.
+//  Copyright © 2025 Moonlight Game Streaming Project. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+@interface PaddedLabel : UILabel
+
+@property (nonatomic, assign) UIEdgeInsets textInsets;
+
+@end

--- a/Limelight/Utility/PaddedLabel.m
+++ b/Limelight/Utility/PaddedLabel.m
@@ -1,0 +1,37 @@
+//
+//  PaddedLabel.m
+//  Moonlight
+//
+//  Created by Travis Thieman on 5/6/25.
+//  Copyright © 2025 Moonlight Game Streaming Project. All rights reserved.
+//
+
+#import "PaddedLabel.h"
+
+@implementation PaddedLabel
+
+- (instancetype)initWithFrame:(CGRect)frame {
+    if (self = [super initWithFrame:frame]) {
+        self.textInsets = UIEdgeInsetsMake(8, 8, 8, 8); // default insets
+    }
+    return self;
+}
+
+- (void)drawTextInRect:(CGRect)rect {
+    UIEdgeInsets insets = self.textInsets;
+    [super drawTextInRect:UIEdgeInsetsInsetRect(rect, insets)];
+}
+
+- (CGSize)intrinsicContentSize {
+    CGSize size = [super intrinsicContentSize];
+    return CGSizeMake(size.width + self.textInsets.left + self.textInsets.right,
+                      size.height + self.textInsets.top + self.textInsets.bottom);
+}
+
+- (CGSize)sizeThatFits:(CGSize)size {
+    CGSize fittingSize = [super sizeThatFits:size];
+    return CGSizeMake(fittingSize.width + self.textInsets.left + self.textInsets.right,
+                      fittingSize.height + self.textInsets.top + self.textInsets.bottom);
+}
+
+@end

--- a/Limelight/ViewControllers/StreamFrameViewController.m
+++ b/Limelight/ViewControllers/StreamFrameViewController.m
@@ -12,6 +12,7 @@
 #import "StreamManager.h"
 #import "ControllerSupport.h"
 #import "DataManager.h"
+#import "PaddedLabel.h"
 
 #include <sys/socket.h>
 #include <netinet/in.h>
@@ -39,7 +40,7 @@
     UITapGestureRecognizer *_menuTapGestureRecognizer;
     UITapGestureRecognizer *_menuDoubleTapGestureRecognizer;
     UITapGestureRecognizer *_playPauseTapGestureRecognizer;
-    UITextView *_overlayView;
+    PaddedLabel *_overlayView;
     UILabel *_stageLabel;
     UILabel *_tipLabel;
     UIActivityIndicatorView *_spinner;
@@ -263,13 +264,17 @@
 
 - (void)updateOverlayText:(NSString*)text {
     if (_overlayView == nil) {
-        _overlayView = [[UITextView alloc] init];
+        _overlayView = [[PaddedLabel alloc] initWithFrame:CGRectZero];
+        [_overlayView setTextInsets:UIEdgeInsetsMake(10, 15, 10, 15)];
+        
 #if !TARGET_OS_TV
         [_overlayView setEditable:NO];
 #endif
+        
         [_overlayView setUserInteractionEnabled:NO];
-        [_overlayView setSelectable:NO];
-        [_overlayView setScrollEnabled:NO];
+        [_overlayView setNumberOfLines:100];
+        [_overlayView.layer setCornerRadius:12];
+        [_overlayView.layer setMasksToBounds:YES];
         
         // HACK: If not using stats overlay, center the text
         if (_statsUpdateTimer == nil) {
@@ -279,11 +284,11 @@
         [_overlayView setTextColor:[UIColor lightGrayColor]];
         [_overlayView setBackgroundColor:[UIColor blackColor]];
 #if TARGET_OS_TV
-        [_overlayView setFont:[UIFont systemFontOfSize:24]];
+        [_overlayView setFont:[UIFont systemFontOfSize:24 weight:UIFontWeightMedium]];
 #else
-        [_overlayView setFont:[UIFont systemFontOfSize:12]];
+        [_overlayView setFont:[UIFont systemFontOfSize:12 weight:UIFontWeightMedium]];
 #endif
-        [_overlayView setAlpha:0.5];
+        [_overlayView setAlpha:0.6];
         [self.view addSubview:_overlayView];
     }
     
@@ -297,7 +302,7 @@
                                            _overlayView.frame.size.height)];
         [_overlayView setText:text];
         [_overlayView sizeToFit];
-        [_overlayView setCenter:CGPointMake(self.view.frame.size.width / 2, _overlayView.frame.size.height / 2)];
+        [_overlayView setCenter:CGPointMake(self.view.frame.size.width / 2, (12 + (_overlayView.frame.size.height / 2)))];
         [_overlayView setHidden:NO];
     }
     else {

--- a/Limelight/ViewControllers/StreamFrameViewController.m
+++ b/Limelight/ViewControllers/StreamFrameViewController.m
@@ -267,10 +267,6 @@
         _overlayView = [[PaddedLabel alloc] initWithFrame:CGRectZero];
         [_overlayView setTextInsets:UIEdgeInsetsMake(10, 15, 10, 15)];
         
-#if !TARGET_OS_TV
-        [_overlayView setEditable:NO];
-#endif
-        
         [_overlayView setUserInteractionEnabled:NO];
         [_overlayView setNumberOfLines:100];
         [_overlayView.layer setCornerRadius:12];

--- a/Moonlight.xcodeproj/project.pbxproj
+++ b/Moonlight.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		4A37FDA52DCAD28F00441192 /* PaddedLabel.m in Sources */ = {isa = PBXBuildFile; fileRef = 4A37FDA42DCAD28F00441192 /* PaddedLabel.m */; };
+		4A37FDA62DCAD28F00441192 /* PaddedLabel.m in Sources */ = {isa = PBXBuildFile; fileRef = 4A37FDA42DCAD28F00441192 /* PaddedLabel.m */; };
 		693B3A9B218638CD00982F7B /* Settings.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 693B3A9A218638CD00982F7B /* Settings.bundle */; };
 		98181BE92791277400E43572 /* libSDL2.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 98181BE82791275D00E43572 /* libSDL2.a */; };
 		98181BEB2791278F00E43572 /* libSDL2.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 98181BEA2791278300E43572 /* libSDL2.a */; };
@@ -170,6 +172,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		4A37FDA32DCAD28F00441192 /* PaddedLabel.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PaddedLabel.h; sourceTree = "<group>"; };
+		4A37FDA42DCAD28F00441192 /* PaddedLabel.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PaddedLabel.m; sourceTree = "<group>"; };
 		566E9D2B2770B23A00EF7BFE /* Moonlight v1.7.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Moonlight v1.7.xcdatamodel"; sourceTree = "<group>"; };
 		693B3A9A218638CD00982F7B /* Settings.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; path = Settings.bundle; sourceTree = "<group>"; };
 		9803CCAB254F9EAF00EE185E /* ConnectionCallbacks.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ConnectionCallbacks.h; sourceTree = "<group>"; };
@@ -562,6 +566,8 @@
 				FB89462219F646E200339C8A /* Utils.m */,
 				FBD1C8E01A8AD69E00C6703C /* Logger.h */,
 				FBD1C8E11A8AD71400C6703C /* Logger.m */,
+				4A37FDA32DCAD28F00441192 /* PaddedLabel.h */,
+				4A37FDA42DCAD28F00441192 /* PaddedLabel.m */,
 			);
 			path = Utility;
 			sourceTree = "<group>";
@@ -854,6 +860,7 @@
 				FB1A67CF213245F800507771 /* TemporaryApp.m in Sources */,
 				FB1A67D1213245F800507771 /* TemporaryHost.m in Sources */,
 				FB1A67D3213245F800507771 /* TemporarySettings.m in Sources */,
+				4A37FDA52DCAD28F00441192 /* PaddedLabel.m in Sources */,
 				FB1A67C3213245EA00507771 /* AppAssetManager.m in Sources */,
 				FB1A67C5213245EA00507771 /* AppAssetRetriever.m in Sources */,
 				FB1A67C7213245EA00507771 /* PairManager.m in Sources */,
@@ -900,6 +907,7 @@
 				9897B6A1221260EF00966419 /* Controller.m in Sources */,
 				FB89462919F646E200339C8A /* mkcert.c in Sources */,
 				FB9AFD281A7C84ED00872C98 /* HttpResponse.m in Sources */,
+				4A37FDA62DCAD28F00441192 /* PaddedLabel.m in Sources */,
 				FBDE86E019F7A837001C18A8 /* UIComputerView.m in Sources */,
 				FB89463019F646E200339C8A /* StreamConfiguration.m in Sources */,
 				FBD3495319FF36FB002D2A60 /* SWRevealViewController.m in Sources */,


### PR DESCRIPTION
As part of a general performance investigation, I found out that rendering the stats overlay was taking up to 20ms on my ATV 4K 1st Gen. This hangs the main thread long enough that the next displayLinkCallback is missed and results in skipped frames. A snapshot from a profile below shows a spike where the main thread was saturated due to activity related to `updateOverlayText`.

<img width="851" alt="Pasted Graphic" src="https://github.com/user-attachments/assets/5c8a74af-ccea-43d8-8958-805ab4b84908" />

Our goal here is to reduce the time spent drawing the stats overlay. To do this, we switch the overlay from a UITextView to a UILabel. I am a complete novice at iOS, I just tried this because the UILabel seemed like a simpler solution for rendering a simple stats overlay. However, this did seem to improve the rendering times by quite a bit. On the same device, I'm seeing `updateOverlayText` typically take only around 3ms now, down from 20ms. This has removed the visible frame skips that previously happened with the stats overlay is displayed.

As part of this, also took another stab at styling the overlay since the default UILabel was pretty ugly. Added a bit of margin at the top, increased opacity slightly, and increased font weight. I think the new label is much more legible but you can still see through to the content if you need to.

Screenshot of the new label

<img width="576" alt="image" src="https://github.com/user-attachments/assets/af19a905-115a-408c-9e26-3468e40b8246" />
