### PR TITLE
Add mouse support for tvOS

### DIFF
--- a/Limelight/Input/ControllerSupport.m
+++ b/Limelight/Input/ControllerSupport.m
@@ -829,7 +829,7 @@ static const double MOUSE_SPEED_DIVISOR = 1.25;
     }
 }
 
--(void) unregisterMouseCallbacks:(GCMouse*)mouse API_AVAILABLE(ios(14.0)) {
+-(void) unregisterMouseCallbacks:(GCMouse*)mouse API_AVAILABLE(ios(14.0), tvos(14.0)) {
     mouse.mouseInput.mouseMovedHandler = nil;
     
     mouse.mouseInput.leftButton.pressedChangedHandler = nil;
@@ -846,7 +846,7 @@ static const double MOUSE_SPEED_DIVISOR = 1.25;
 #endif
 }
 
--(void) registerMouseCallbacks:(GCMouse*) mouse API_AVAILABLE(ios(14.0)) {
+-(void) registerMouseCallbacks:(GCMouse*) mouse API_AVAILABLE(ios(14.0), tvos(14.0)) {
     mouse.mouseInput.mouseMovedHandler = ^(GCMouseInput * _Nonnull mouse, float deltaX, float deltaY) {
         self->accumulatedDeltaX += deltaX / MOUSE_SPEED_DIVISOR;
         self->accumulatedDeltaY += -deltaY / MOUSE_SPEED_DIVISOR;

--- a/Moonlight TV/Info.plist
+++ b/Moonlight TV/Info.plist
@@ -27,6 +27,8 @@
 			<string>ExtendedGamepad</string>
 		</dict>
 	</array>
+	<key>GCSupportsMouseAndKeyboard</key>
+	<true/>
 	<key>GCSupportsControllerUserInteraction</key>
 	<true/>
 	<key>ITSAppUsesNonExemptEncryption</key>
@@ -39,9 +41,9 @@
 		<true/>
 	</dict>
 	<key>NSBluetoothAlwaysUsageDescription</key>
-	<string>Bluetooth access allows Moonlight to connect to Citrix X1 mice.</string>
+	<string>Bluetooth access allows Moonlight to connect to Bluetooth mice.</string>
 	<key>NSBluetoothPeripheralUsageDescription</key>
-	<string>Bluetooth access allows Moonlight to connect to Citrix X1 mice.</string>
+	<string>Bluetooth access allows Moonlight to connect to Bluetooth mice.</string>
 	<key>NSBonjourServices</key>
 	<array>
 		<string>_nvstream._tcp</string>


### PR DESCRIPTION
Extended mouse callback registration to tvOS 14.0+ in ControllerSupport.m and enabled GCSupportsMouseAndKeyboard in the Moonlight TV Info.plist. Updated Bluetooth usage descriptions to reference Bluetooth mice instead of Citrix X1 mice.

https://developer.apple.com/documentation/gamecontroller/gcmouse