### PR TITLE
Add  a seperate thread for CMSampleBuffer handling and submitting.

### DIFF
--- a/Limelight/Stream/Connection.m
+++ b/Limelight/Stream/Connection.m
@@ -423,6 +423,9 @@ void ClSetControllerLED(uint16_t controllerNumber, uint8_t r, uint8_t g, uint8_t
     _streamConfig.supportedVideoFormats = config.supportedVideoFormats;
     _streamConfig.audioConfiguration = config.audioConfiguration;
     
+    _streamConfig.colorSpace = COLORSPACE_REC_709;
+    _streamConfig.colorRange = COLOR_RANGE_FULL;
+    
     // Since we require iOS 12 or above, we're guaranteed to be running
     // on a 64-bit device with ARMv8 crypto instructions, so we don't
     // need to check for that here.

--- a/Limelight/Stream/VideoDecoderRenderer.m
+++ b/Limelight/Stream/VideoDecoderRenderer.m
@@ -131,8 +131,7 @@ int DrSubmitDecodeUnit(PDECODE_UNIT decodeUnit);
 
 - (void)displayLinkCallback:(CADisplayLink *)sender
 {
-    if(!framePacing)
-    {
+    if(!framePacing) {
         return;
     }
     // Calculate the actual display refresh rate
@@ -142,24 +141,22 @@ int DrSubmitDecodeUnit(PDECODE_UNIT decodeUnit);
     // Battery saver, accessibility settings, or device thermals can cause the actual
     // refresh rate of the display to drop below the physical maximum.
     NSUInteger bufferSize = 0;
-    if (displayRefreshRate >= frameRate * 0.9f)
-    {
+    if (displayRefreshRate >= frameRate * 0.9f) {
         bufferSize = 1;
     }
     // Always try to pop one frame per refresh
+    [_queueLock lock];
     do {
-        if(_sampleBufferQueue.count == 0)
-        {
+        if(_sampleBufferQueue.count == 0) {
             break;
         }
-        [_queueLock lock];
+        
         CMSampleBufferRef sampleBuffer = (__bridge CMSampleBufferRef)_sampleBufferQueue.firstObject;
         [_sampleBufferQueue removeObjectAtIndex:0];
-        [_queueLock unlock];
         [self->displayLayer enqueueSampleBuffer:sampleBuffer];
         CFRelease(sampleBuffer);
-    }while (_sampleBufferQueue.count > bufferSize); // If possible, keep 1 frame to avoid jittering.
-    
+    } while (_sampleBufferQueue.count > bufferSize); // If possible, keep 1 frame to avoid jittering.
+    [_queueLock unlock];
 }
 
 - (void)decodeThreadMain {
@@ -168,11 +165,8 @@ int DrSubmitDecodeUnit(PDECODE_UNIT decodeUnit);
     PDECODE_UNIT du;
     while (_running && ![[NSThread currentThread] isCancelled]) {
         @autoreleasepool {
-            {
-                if(!LiWaitForNextVideoFrame(&handle,&du))
-                {
-                    continue;
-                }
+            if(!LiWaitForNextVideoFrame(&handle,&du)) {
+                continue;
             }
             LiCompleteVideoFrame(handle, DrSubmitDecodeUnit(du));
         }
@@ -194,7 +188,7 @@ int DrSubmitDecodeUnit(PDECODE_UNIT decodeUnit);
         CFRelease(sampleBuffer);
     }
     [_queueLock unlock];
-    if(_displayLink){
+    if(_displayLink) {
         [_displayLink invalidate];
     }
 }
@@ -649,14 +643,12 @@ int DrSubmitDecodeUnit(PDECODE_UNIT decodeUnit);
     }
 
     // Enqueue the next frame
-    if(framePacing)
-    {
+    if(framePacing) {
         [_queueLock lock];
         [_sampleBufferQueue addObject:(__bridge id)sampleBuffer];
         [_queueLock unlock];
     }
-    else
-    {
+    else {
         [self->displayLayer enqueueSampleBuffer:sampleBuffer];
         CFRelease(sampleBuffer);
     }

--- a/Limelight/Stream/VideoDecoderRenderer.m
+++ b/Limelight/Stream/VideoDecoderRenderer.m
@@ -635,6 +635,15 @@ int DrSubmitDecodeUnit(PDECODE_UNIT decodeUnit);
                                   formatDesc, 1, 1,
                                   &sampleTiming, 0, NULL,
                                   &sampleBuffer);
+    
+    CFArrayRef attachmentsArray = CMSampleBufferGetSampleAttachmentsArray(sampleBuffer, YES);
+    if (attachmentsArray && CFArrayGetCount(attachmentsArray) > 0) {
+        CFMutableDictionaryRef attachments = (CFMutableDictionaryRef)CFArrayGetValueAtIndex(attachmentsArray, 0);
+        if (attachments) {
+            // sunshine don't use B-frames, hint decoder about this.
+            CFDictionarySetValue(attachments, kCMSampleAttachmentKey_EarlierDisplayTimesAllowed, kCFBooleanTrue);
+        }
+    }
     if (status != noErr) {
         Log(LOG_E, @"CMSampleBufferCreate failed: %d", (int)status);
         CFRelease(dataBlockBuffer);

--- a/Limelight/Stream/VideoDecoderRenderer.m
+++ b/Limelight/Stream/VideoDecoderRenderer.m
@@ -131,7 +131,7 @@ int DrSubmitDecodeUnit(PDECODE_UNIT decodeUnit);
 
 - (void)displayLinkCallback:(CADisplayLink *)sender
 {
-    if(framePacing)
+    if(!framePacing)
     {
         return;
     }

--- a/Limelight/Stream/VideoDecoderRenderer.m
+++ b/Limelight/Stream/VideoDecoderRenderer.m
@@ -123,6 +123,7 @@ extern int ff_isom_write_av1c(AVIOContext *pb, const uint8_t *buf, int size,
     [_displayLink addToRunLoop:[NSRunLoop mainRunLoop] forMode:NSDefaultRunLoopMode];
 
     _submitThread = [[NSThread alloc] initWithTarget:self selector:@selector(decodeThreadMain) object:nil];
+    [_submitThread setQualityOfService:NSQualityOfServiceUserInteractive];
     [_submitThread start];
 }
 


### PR DESCRIPTION
In the original implementation, the CMSampleBuffer was submitted to the CADisplayLayer during the VSync callback, which introduced additional latency.
In the new implementation, a dedicated submitter thread is blocked by LiWaitForNextVideoFrame(). As soon as a new frame is available, it is processed and submitted to the CADisplayLayer immediately. This allows the hardware decoder to start working as early as possible, thereby reducing overall latency.
On the other hand, when frame pacing is enabled, the CMSampleBuffer is placed into a queue and submitted to the decoder during the VSync callback. This approach keeps the behavior consistent with the original implementation.
