### PR TITLE
Adopt the UIScene lifecycle on tvOS

### DIFF
--- a/Limelight/AppDelegate.m
+++ b/Limelight/AppDelegate.m
@@ -8,6 +8,30 @@
 
 #import "AppDelegate.h"
 
+#if TARGET_OS_TV
+// tvOS 27's SDK enforces the UIScene lifecycle, so provide a minimal window-scene
+// delegate that builds the window from the Main storyboard. Declared here (already in
+// the tvOS target) to avoid adding a new source file to the project.
+API_AVAILABLE(tvos(13.0))
+@interface SceneDelegate : UIResponder <UIWindowSceneDelegate>
+@property (strong, nonatomic) UIWindow *window;
+@end
+
+@implementation SceneDelegate
+- (void)scene:(UIScene *)scene willConnectToSession:(UISceneSession *)session options:(UISceneConnectionOptions *)connectionOptions {
+    if (![scene isKindOfClass:[UIWindowScene class]]) {
+        return;
+    }
+    UIWindowScene *windowScene = (UIWindowScene *)scene;
+    UIWindow *window = [[UIWindow alloc] initWithWindowScene:windowScene];
+    UIStoryboard *storyboard = [UIStoryboard storyboardWithName:@"Main" bundle:nil];
+    window.rootViewController = [storyboard instantiateInitialViewController];
+    self.window = window;
+    [window makeKeyAndVisible];
+}
+@end
+#endif
+
 @implementation AppDelegate
 
 @synthesize managedObjectContext = _managedObjectContext;

--- a/Limelight/ViewControllers/StreamFrameViewController.m
+++ b/Limelight/ViewControllers/StreamFrameViewController.m
@@ -587,7 +587,13 @@
 - (void) updatePreferredDisplayMode:(BOOL)streamActive {
 #if TARGET_OS_TV
     if (@available(tvOS 11.2, *)) {
-        UIWindow* window = [[[UIApplication sharedApplication] delegate] window];
+        // Under the UIScene lifecycle the window belongs to the scene, not the app
+        // delegate (whose -window is nil), so get it from our own view. Fall back to
+        // the app delegate's window for the legacy (pre-scene) lifecycle.
+        UIWindow* window = self.view.window;
+        if (window == nil) {
+            window = [[[UIApplication sharedApplication] delegate] window];
+        }
         AVDisplayManager* displayManager = [window avDisplayManager];
         
         // This logic comes from Kodi and MrMC

--- a/Moonlight TV/Info.plist
+++ b/Moonlight TV/Info.plist
@@ -50,6 +50,23 @@
 	<string>Moonlight uses the local network to connect to your gaming PC for streaming.</string>
 	<key>UIMainStoryboardFile</key>
 	<string>Main</string>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneConfigurationName</key>
+					<string>Default Configuration</string>
+					<key>UISceneDelegateClassName</key>
+					<string>SceneDelegate</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
 	<key>UIRequiredDeviceCapabilities</key>
 	<array>
 		<string>arm64</string>


### PR DESCRIPTION
## Problem

An app built against the **tvOS 27 SDK** that still uses the legacy `UIApplicationMain` + storyboard lifecycle fails to launch. The system refuses to create its scene and the app exits before `main`, with this in the device log:

```
Application failed to launch: UIScene life cycle is required for apps built with this SDK.
See "Transitioning to the UIKit scene-based life cycle" ...
[FBSceneManager] Scene creation failed: ... ("scene-creation-failed")
```

Apps built against the tvOS **26.5** SDK are exempt and still run on tvOS 27, so this only bites once you build the tvOS target with Xcode 27 / the tvOS 27 SDK.

## Fix

- Add a minimal `UIApplicationSceneManifest` to `Moonlight TV/Info.plist`.
- Add a small `UIWindowSceneDelegate` that builds the window from the `Main` storyboard. To avoid adding a new source file to the project, it's declared in `AppDelegate.m` under `#if TARGET_OS_TV`.
- Make the tvOS HDR / refresh-rate code scene-safe: under the scene lifecycle the app delegate's `-window` is `nil`, so `updatePreferredDisplayMode:` now reads the window from the view controller (`self.view.window`) with a fallback to the app delegate's window for the legacy lifecycle.

## Notes

- **Backward compatible.** The scene manifest is honored on tvOS versions that support scenes; on older tvOS the app falls back to the legacy lifecycle, so this doesn't raise the effective minimum.
- **tvOS only.** Only the tvOS target is touched. The iOS target is unchanged; it will need the same migration when built against a future iOS SDK that enforces scenes (that's a larger change — SWRevealViewController, shortcut-item handling — so I've left it out of this PR).
- Does not change `TVOS_DEPLOYMENT_TARGET`.

## Testing

Built with **Xcode 27 beta** against the tvOS 27 SDK and run on an **Apple TV 4K (3rd gen), tvOS 27.0 (24J5346a)**: the app launches, the UI appears, host discovery/pairing work, and streaming works. Also verified the **tvOS 26.5-SDK** build (Xcode 26.6) still launches and runs normally with this change (no regression).

